### PR TITLE
Bulk Processing Bug

### DIFF
--- a/resmushit.php
+++ b/resmushit.php
@@ -115,7 +115,7 @@ function resmushit_process_images($attachments, $force_keep_original = TRUE) {
 	return $attachments;
 }
 //Automatically optimize images if option is checked
-if(get_option('resmushit_on_upload'))
+if(get_option('resmushit_on_upload') OR ( isset($_POST['action']) AND $_POST['action'] === "resmushit_bulk_process_image" ))
 	add_filter('wp_generate_attachment_metadata', 'resmushit_process_images');   
  
 


### PR DESCRIPTION
This code fixes a bug where you cannot bulk process images unless Optimize on upload is selected.

The resmushit_bulk_process_image calls reSmushit::revert which calls wp_generate_attachment_metadata to smush the image. The wp_generate_attachment_metadata hook for resmushit_process_images is only installed when the resmushit_on_upload is enabled meaning that the bulk process will not run when resmushit_on_upload is not selected.