### PR TITLE
Added plugin 'Settings' link

### DIFF
--- a/resmushit.php
+++ b/resmushit.php
@@ -251,4 +251,19 @@ function resmushit_update_statistics() {
 	echo json_encode($output);
 	die();
 }
-add_action( 'wp_ajax_resmushit_update_statistics', 'resmushit_update_statistics' );	
+add_action( 'wp_ajax_resmushit_update_statistics', 'resmushit_update_statistics' );
+
+
+
+
+
+/**
+ * add 'Settings' link to options page from Plugins
+ * @param array $links
+ * @return string
+ */
+function resmushit_add_plugin_page_settings_link($links) {
+	$links[] = '<a href="' . admin_url( 'upload.php?page=resmushit_options' ) . '">' . __('Settings') . '</a>';
+	return $links;
+}
+add_filter('plugin_action_links_'.plugin_basename(__FILE__), 'resmushit_add_plugin_page_settings_link');


### PR DESCRIPTION
I have added settings link to reSmush.it option page from Plugins. It's tied with [this issue](https://github.com/charlyie/resmushit-wordpress/issues/5).

Fix was created based on [this](https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)) code.