### PR TITLE
Allow uppercase version of allowed extensions

### DIFF
--- a/resmushit.php
+++ b/resmushit.php
@@ -114,7 +114,7 @@ function resmushit_process_images($attachments, $force_keep_original = TRUE) {
 	$basefile = basename($attachments[ 'file' ]);
 
 	// Optimize only pictures/files accepted by the API
-	if( !in_array($extension, resmushit::authorizedExtensions()) ) {
+	if( !in_array(strtolower($extension), resmushit::authorizedExtensions()) ) {
 		return $attachments;	
 	}
 


### PR DESCRIPTION
I have a lot of images provided by a digital camera which are originally saved in uppercase extension ".JPG".
In my case the cronjob always retries the attachments in a loop and never finish.
My patch convert the extension for lookup to lowercase so that .PNG or .JPG can be processed.
